### PR TITLE
Custom responses

### DIFF
--- a/Economy/Settings-administrative/add-response.cc.go
+++ b/Economy/Settings-administrative/add-response.cc.go
@@ -2,7 +2,7 @@
 		Made by Ranger (765316548516380732)
 
 	Trigger Type: `Regex`
-	Trigger: `\A(-|<@!?204255221017214977>\s*)((add-?)?response)(\s+|\z)`
+	Trigger: `\A(-|<@!?204255221017214977>\s*)((add-?)?response(s)?)(\s+|\z)`
 
 	©️ Ranger 2020-Present
 	GNU, GPLV3 License

--- a/Economy/Settings-administrative/add-response.cc.go
+++ b/Economy/Settings-administrative/add-response.cc.go
@@ -1,0 +1,95 @@
+{{/*
+		Made by Ranger (765316548516380732)
+
+	Trigger Type: `Regex`
+	Trigger: `\A(-|<@!?204255221017214977>\s*)((add-?)?response)(\s+|\z)`
+
+	©️ Ranger 2020-Present
+	GNU, GPLV3 License
+	Repository: https://github.com/Ranger-4297/YAGPDB-ccs
+*/}}
+
+{{/* Only edit below if you know what you're doing (: rawr */}}
+
+{{/* Initiates variables */}}
+{{$userID := .User.ID}}
+{{$successColor := 0x00ff7b}}
+{{$errorColor := 0xFF0000}}
+{{$prefix := .ServerPrefix}}
+
+{{/* Set */}}
+
+{{/* Response */}}
+{{$embed := sdict}}
+{{$embed.Set "author" (sdict "name" $.User.Username "icon_url" ($.User.AvatarURL "1024"))}}
+{{$embed.Set "timestamp" currentTime}}
+{{$db := or (dbGet 0 "EconomySettings").Value (sdict "min" 200 "max" 500 "betMax" 5000 "symbol" "£" "startBalance" 200 "incomeCooldown" 300 "workCooldown" 7200 "crimeCooldown" 14400 "robCooldown" 21600 "responses" (sdict "crime" cslice "work" cslice))}}
+{{$perms := split (index (split (exec "viewperms") "\n") 2) ", "}}
+{{if or (in $perms "Administrator") (in $perms "ManageServer")}}
+	{{with $db}}
+		{{$responses := or ($db.responses) (sdict "crime" cslice "work" cslice)}}
+		{{with $.CmdArgs}}
+			{{$type := (index $.CmdArgs 0) | lower}}
+			{{if eq $type "work" "crime"}}
+				{{if gt (len $.CmdArgs) 1}}
+					{{$response := (joinStr " " (slice $.CmdArgs 1))}}
+					{{if (reFind `\(amount\)` $response)}}
+						{{$currentResponses := $responses.Get $type}}
+						{{$currentResponses = $currentResponses.Append $response}}
+						{{$responses.Set $type $currentResponses}}
+						{{$embed.Set "description" (print "Successfully added \"" (reReplace `\(amount\)` $response "`(amount)`") "\" to the list of responses.\nTo view the list of responses in it's entirey. Please use the command `" $.Cmd " list`")}}
+						{{$embed.Set "color" $successColor}}
+						{{$db.Set "responses" $responses}}
+					{{else}}
+						{{$embed.Set "description" (print "Please include the exact string `(amount)` as a placeholder for where the amount goes.")}}
+						{{$embed.Set "color" $errorColor}}
+					{{end}}
+				{{else}}
+					{{$embed.Set "description" (print "No `Response` argument passed.\nSyntax is: `" $.Cmd " " $type " <Reponse>`")}}
+					{{$embed.Set "color" $errorColor}}
+				{{end}}
+			{{else if eq $type "list"}}
+				{{if gt (len $.CmdArgs) 1}}
+					{{$type := (index $.CmdArgs 1) | lower}}
+					{{if eq $type "work" "crime"}}
+						{{$typeResponses := $responses.Get $type}}
+						{{if $typeResponses}}
+							{{$responseNumber := 0}}
+							{{$fields := cslice}}
+							{{range $typeResponses}}
+								{{- $fields = $fields.Append (sdict "Name" (print "Response: " $responseNumber) "value" (reReplace `\(amount\)` . "`(amount)`") "inline" false) -}}
+								{{$responseNumber = $responseNumber | add 1}}
+							{{end}}
+							{{$embed.Set "description" (print "All responses for " $type "-based payouts are\nPlease note. This doesn't support pages yet.")}}
+							{{$embed.Set "fields" $fields}}
+							{{$embed.Set "color" $successColor}}
+						{{else}}
+							{{$embed.Set "description" (print "No responses for this type have been set.\nAdd some with `" $.Cmd " <Type:Work/Crime> <Response>`")}}
+							{{$embed.Set "color" $errorColor}}
+						{{end}}
+					{{else}}
+						{{$embed.Set "description" (print "Invalid `type` argument passed.\nSyntax is: `" $.Cmd " list <Type:Work/Crime>`")}}
+						{{$embed.Set "color" $errorColor}}
+					{{end}}
+				{{else}}
+					{{$embed.Set "description" (print "No `type` argument passed.\nSyntax is: `" $.Cmd " list <Type:Work/Crime>`")}}
+					{{$embed.Set "color" $errorColor}}
+				{{end}}
+			{{else}}
+				{{$embed.Set "description" (print "Invalid `type` argument passed.\nSyntax is: `" $.Cmd " <Type:Work/Crime> <Reponse>`")}}
+				{{$embed.Set "color" $errorColor}}
+			{{end}}
+		{{else}}
+			{{$embed.Set "description" (print "No `type` argument passed.\nSyntax is: `" $.Cmd " <Type:Work/Crime> <Reponse>`")}}
+			{{$embed.Set "color" $errorColor}}
+		{{end}}
+	{{else}}
+		{{$embed.Set "description" (print "No `type` argument passed.\nSyntax is: `" $.Cmd " <Type:Work/Crime> <Reponse>`")}}
+		{{$embed.Set "color" $errorColor}}
+	{{end}}
+{{else}}
+	{{$embed.Set "description" (print "Insufficient permissions.\nTo use this command you need to have either `Administrator` or `ManageServer` permissions")}}
+	{{$embed.Set "color" $errorColor}}
+{{end}}
+{{dbSet 0 "EconomySettings" $db}}
+{{sendMessage nil (cembed $embed)}}

--- a/Economy/Settings-administrative/server-set.cc.go
+++ b/Economy/Settings-administrative/server-set.cc.go
@@ -25,7 +25,7 @@
 {{$db := (dbGet 0 "EconomySettings").Value}}
 {{$perms := split (index (split (exec "viewperms") "\n") 2) ", "}}
 {{if or (in $perms "Administrator") (in $perms "ManageServer")}}
-	{{$syntax := (print "\nAvailable settings: `max`, `min`, `betMax`, `startbalance`, `symbol`, `workCD`, `incomeCD`, `crimeCD`, `robCD`\nTo set it with the default settings `" $.Cmd " default`")}}
+	{{$syntax := (print "\nAvailable settings: `max`, `min`, `betMax`, `startbalance`, `symbol`, `workCD`, `incomeCD`, `crimeCD`, `robCD`, `responses`\nTo set it with the default settings `" $.Cmd " default`")}}
 	{{with .CmdArgs}}
 		{{if index $.CmdArgs 0}}
 			{{$setting := (index $.CmdArgs 0) | lower}}
@@ -33,7 +33,7 @@
 			{{if eq $setting "default"}}
 				{{$msg.Set "description" (print "Set the `EconomySettings` to default values")}}
 				{{$msg.Set "color" $sC}}
-				{{dbSet 0 "EconomySettings" (sdict "min" 200 "max" 500 "betMax" 5000 "symbol" "£" "startBalance" 200 "incomeCooldown" 300 "workCooldown" 7200 "crimeCooldown" 14400 "robCooldown" 21600)}}
+				{{dbSet 0 "EconomySettings" (sdict "min" 200 "max" 500 "betMax" 5000 "symbol" "£" "startBalance" 200 "incomeCooldown" 300 "workCooldown" 7200 "crimeCooldown" 14400 "robCooldown" 21600 "enable-responses" false "responses" (sdict "work" cslice "crime" cslice))}}
 				{{dbSet 0 "store" sdict}}
 				{{dbSet 0 "russianRoulette" sdict}}
 				{{dbSet 0 "bank"}}
@@ -106,6 +106,28 @@
 							{{$msg.Set "color" $sC}}
 							{{$db.Set "symbol" $symbol}}
 							{{dbSet 0 "EconomySettings" $db}}
+						{{else}}
+							{{$msg.Set "description" (print $nv "\nSyntax is: `" $.Cmd " " $setting " <Value>`")}}
+						{{end}}
+					{{else if eq $setting "responses"}}
+						{{if gt (len $.CmdArgs) 1}}
+							{{$value := (index $.CmdArgs 1) | lower}}
+							{{if eq $value "yes" "enable" "enabled" "no" "disable" "disabled"}}
+								{{$status := ""}}
+								{{if eq $value "yes" "enable" "enabled"}}
+									{{$status = "enabled"}}
+									{{$value = true}}
+								{{else}}
+									{{$status = "disabled"}}
+									{{$value = false}}
+								{{end}}
+								{{$msg.Set "description" (print "You " $status " custom responses")}}
+								{{$msg.Set "color" $sC}}
+								{{$db.Set "enable-responses" $value}}
+								{{dbSet 0 "EconomySettings" $db}}
+							{{else}}
+								{{$msg.Set "description" (print $nv "\nSyntax is: `" $.Cmd " " $setting " <Value>`")}}
+							{{end}}
 						{{else}}
 							{{$msg.Set "description" (print $nv "\nSyntax is: `" $.Cmd " " $setting " <Value>`")}}
 						{{end}}


### PR DESCRIPTION
Implements custom responses for `work` and successful `crime` commands.
Toggled with `set responses` available options are: `yes`, `no`, `enable`, `disable`, `enabled`, `disabled`
Created with `addresponse`, list all responses with `response list`