### PR TITLE
Update no economySettings DB  message

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -40,7 +40,7 @@
 			"    {{$$a := sdict .Value}}",
 			"    $1",
 			"{{else}}",
-			"    {{$$embed.Set \"description\" (print \"No `Settings` database found.\\nPlease set it up with the default values using `\" $$prefix \"set default`\")}}",
+			"    {{$$embed.Set \"description\" (print \"No `Settings` database found.\\nPlease set it up with the default values using `\" $$prefix \"server-set default`\")}}",
 			"    {{$$embed.Set \"color\" $$errorColor}}",
 			"{{end}}"
 		]

--- a/Economy/Informational/balance.cc.go
+++ b/Economy/Informational/balance.cc.go
@@ -80,7 +80,7 @@
 		{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Informational/leaderboard.cc.go
+++ b/Economy/Informational/leaderboard.cc.go
@@ -63,7 +63,7 @@
 		{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/MoneyMaking/cockFight.cc.go
+++ b/Economy/MoneyMaking/cockFight.cc.go
@@ -105,7 +105,7 @@
 	{{$econData.Set "cfWinChance" $cfWC}}
 	{{dbSet $userID "userEconData" $econData}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/MoneyMaking/coinFlip.cc.go
+++ b/Economy/MoneyMaking/coinFlip.cc.go
@@ -107,7 +107,7 @@
 	{{end}}
 	{{dbSet $userID "cash" $bal}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/MoneyMaking/roll-snakeeyes.cc.go
+++ b/Economy/MoneyMaking/roll-snakeeyes.cc.go
@@ -120,7 +120,7 @@
 	{{end}}
 	{{dbSet $userID "cash" $bal}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/MoneyMaking/russian-roulette.cc.go
+++ b/Economy/MoneyMaking/russian-roulette.cc.go
@@ -206,7 +206,7 @@
 					{{end}}
 				{{end}}
 			{{else}}
-				{{$em.Set "description" (print "No `russianRoulette` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+				{{$em.Set "description" (print "No `russianRoulette` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 				{{$em.Set "color" $errorColor}}
 			{{end}}
 		{{else}}
@@ -215,7 +215,7 @@
 		{{end}}
 		{{dbSet $userID "cash" $bal}}
 	{{else}}
-		{{$em.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+		{{$em.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 		{{$em.Set "color" $errorColor}}
 	{{end}}
 {{else}}

--- a/Economy/MoneyMaking/work-crime-rob.cc.go
+++ b/Economy/MoneyMaking/work-crime-rob.cc.go
@@ -114,7 +114,7 @@
 	{{end}}
 	{{dbSet $userID "cash" $cash}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/MoneyManagement/add-removeMoney.cc.go
+++ b/Economy/MoneyManagement/add-removeMoney.cc.go
@@ -96,7 +96,7 @@
 			{{$embed.Set "color" $errorColor}}
 		{{end}}
 	{{else}}
-		{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+		{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 		{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{else}}

--- a/Economy/MoneyManagement/dep-with.cc.go
+++ b/Economy/MoneyManagement/dep-with.cc.go
@@ -89,7 +89,7 @@
 		{{dbSet 0 "bank" $bankDB}}
 		{{dbSet $userID "cash" $cash}}
 	{{else}}
-		{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+		{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 		{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{end}}

--- a/Economy/MoneyManagement/giveMoney.cc.go
+++ b/Economy/MoneyManagement/giveMoney.cc.go
@@ -76,7 +76,7 @@
 	{{end}}
 	{{dbSet $userID "cash" $cash}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/MoneyManagement/setbalance.cc.go
+++ b/Economy/MoneyManagement/setbalance.cc.go
@@ -75,7 +75,7 @@
 			{{$embed.Set "color" $errorColor}}
 		{{end}}
     {{else}}
-        {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+        {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
         {{$embed.Set "color" $errorColor}}
     {{end}}
 {{else}}

--- a/Economy/Plugins/Accounts/accounts.cc.go
+++ b/Economy/Plugins/Accounts/accounts.cc.go
@@ -243,6 +243,6 @@
 		{{$e.Set "description" (print "No option argument passed." $o)}}
 	{{end}}
 {{else}}
-	{{$e.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" .ServerPrefix "set default`")}}
+	{{$e.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" .ServerPrefix "server-set default`")}}
 {{end}}
 {{sendMessage nil (cembed $e)}}

--- a/Economy/Plugins/Timely/timely.cc.go
+++ b/Economy/Plugins/Timely/timely.cc.go
@@ -109,7 +109,7 @@
 		{{dbSet $userID "userEconData" $a}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Settings-administrative/reset-user.cc.go
+++ b/Economy/Settings-administrative/reset-user.cc.go
@@ -54,7 +54,7 @@
 			{{$embed.Set "color" $errorColor}}
 		{{end}}
     {{else}}
-        {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+        {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
         {{$embed.Set "color" $errorColor}}
     {{end}}
 {{else}}

--- a/Economy/Settings-administrative/user-set.cc.go
+++ b/Economy/Settings-administrative/user-set.cc.go
@@ -66,7 +66,7 @@
 		{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No economy database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No economy database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Settings-administrative/viewSettings.cc.go
+++ b/Economy/Settings-administrative/viewSettings.cc.go
@@ -73,7 +73,7 @@
 		{{$embed.Set "color" $successColor}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Shop/buy-item.cc.go
+++ b/Economy/Shop/buy-item.cc.go
@@ -138,7 +138,7 @@
 	{{dbSet $userID "userEconData" $userdata}}
 	{{dbSet $userID "cash" $bal}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Shop/create-item.cc.go
+++ b/Economy/Shop/create-item.cc.go
@@ -189,7 +189,7 @@
 	{{else}}
 		{{$embed.Del "footer"}}{{$embed.Del "title"}}
 		{{$embed.Set "author" (sdict "name" $.User.Username "icon_url" ($.User.AvatarURL "1024"))}}
-		{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $.ServerPrefix "set default`")}}
+		{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $.ServerPrefix "server-set default`")}}
 		{{$embed.Set "color" $errorColor}}
 		{{sendMessage nil (cembed $embed)}}
 	{{end}}

--- a/Economy/Shop/edit-item.cc.go
+++ b/Economy/Shop/edit-item.cc.go
@@ -167,7 +167,7 @@
 			{{end}}
 		{{end}}
 	{{else}}
-			{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+			{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 			{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{else}}

--- a/Economy/Shop/inventory.cc.go
+++ b/Economy/Shop/inventory.cc.go
@@ -91,7 +91,7 @@
 		{{$embed.Set "color" $errorColor}}
 	{{end}}
 {{else}}
-    {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+    {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
     {{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Shop/item-info.cc.go
+++ b/Economy/Shop/item-info.cc.go
@@ -63,7 +63,7 @@
 		{{end}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Shop/remove-item.cc.go
+++ b/Economy/Shop/remove-item.cc.go
@@ -53,7 +53,7 @@
 		{{end}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Shop/shop.cc.go
+++ b/Economy/Shop/shop.cc.go
@@ -89,7 +89,7 @@
 		{{end}}
 	{{end}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}

--- a/Economy/Shop/use-item.cc.go
+++ b/Economy/Shop/use-item.cc.go
@@ -58,7 +58,7 @@
 	{{end}}
 	{{dbSet $userID "userEconData" $userdata}}
 {{else}}
-	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "set default`")}}
+	{{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
 	{{$embed.Set "color" $errorColor}}
 {{end}}
 {{sendMessage nil (cembed $embed)}}


### PR DESCRIPTION
Update "No `Settings` database found" error preceded by old `set` command to new `server-set` command