### PR TITLE
Sell item plugin

### DIFF
--- a/Economy/Plugins/Sell/Readme.md
+++ b/Economy/Plugins/Sell/Readme.md
@@ -1,0 +1,8 @@
+# Sell
+
+# Info
+- Sell allows users to add items to the shop from their own inventory for others to buy
+ - This is specifically for adding/trading limited or special items
+- Removes an item you've added to the shop if you leave, permanantly
+- Users cannot buy their own item
+- View who sold the item in the `shop` nd `iteminfo` commands

--- a/Economy/Plugins/Sell/sell.cc.go
+++ b/Economy/Plugins/Sell/sell.cc.go
@@ -1,0 +1,54 @@
+{{/*
+        Made by Ranger (765316548516380732)
+
+    Trigger Type: `Regex`
+    Trigger: `\A(-|<@!?204255221017214977>\s*)(sell)(\s+|\z)`
+
+    ©️ Ranger 2020-Present
+    GNU, GPLV3 License
+    Repository: https://github.com/Ranger-4297/YAGPDB-ccs
+*/}}
+
+
+{{/* Only edit below if you know what you're doing (: rawr */}}
+
+{{/* Initiates variables */}}
+{{$userID := .User.ID}}
+{{$successColor := 0x00ff7b}}
+{{$errorColor := 0xFF0000}}
+{{$prefix := .ServerPrefix}}
+
+{{/* Sell  */}}
+
+{{/* Response */}}
+{{$embed := sdict}}
+{{$embed.Set "author" (sdict "name" $.User.Username "icon_url" ($.User.AvatarURL "1024"))}}
+{{$embed.Set "timestamp" currentTime}}
+{{with dbGet 0 "EconomySettings"}}
+    {{$a := sdict .Value}}
+    {{$symbol := $a.symbol}}
+	{{$userdata := or (dbGet $userID "userEconData").Value (sdict "settings" (sdict "balance" "yes" "inventory" "yes" "leaderboard" "yes" "trading" "yes") "inventory" sdict "streaks" (sdict "daily" 0 "weekly" 0 "monthly" 0))}}
+    {{$inventory := $userdata.inventory}}
+	{{$store := or (dbGet 0 "store").Value (sdict "items" sdict)}}
+    {{$items := $store.items}}
+    {{with $.CmdArgs}}
+        {{$item := (index . 0)}}
+        {{with $inventory.Get $item}}
+            {{$shopEntry := .}}
+            {{$shopEntry.Set "user" $userID}}
+            {{$items.Set $item $shopEntry}}
+        {{else}}
+            {{$embed.Set "description" (print "Invalid <item> argument provided.\nSyntax is `" $.Cmd " <Item:Item name> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+            {{$embed.Set "color" $errorColor}}
+        {{end}}
+    {{else}}
+        {{$embed.Set "description" (print "No <item> argument provided.\nSyntax is `" $.Cmd " <Item:Item name> [Quantity:Int/All]")}}
+        {{$embed.Set "color" $errorColor}}
+    {{end}}
+    {{dbSet 0 "store"}}
+    {{dbSet $userID "userEconData" $userData}}
+{{else}}
+    {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
+    {{$embed.Set "color" $errorColor}}
+{{end}}
+{{sendMessage nil (cembed $embed)}}

--- a/Economy/Plugins/Sell/sell.cc.go
+++ b/Economy/Plugins/Sell/sell.cc.go
@@ -27,72 +27,94 @@
 {{with dbGet 0 "EconomySettings"}}
     {{$a := sdict .Value}}
     {{$symbol := $a.symbol}}
-	{{$userdata := or (dbGet $userID "userEconData").Value (sdict "settings" (sdict "balance" "yes" "inventory" "yes" "leaderboard" "yes" "trading" "yes") "inventory" sdict "streaks" (sdict "daily" 0 "weekly" 0 "monthly" 0))}}
-    {{$inventory := $userdata.inventory}}
+	{{$userData := or (dbGet $userID "userEconData").Value (sdict "settings" (sdict "balance" "yes" "inventory" "yes" "leaderboard" "yes" "trading" "yes") "inventory" sdict "streaks" (sdict "daily" 0 "weekly" 0 "monthly" 0))}}
+    {{$inventory := $userData.inventory}}
 	{{$store := or (dbGet 0 "store").Value (sdict "items" sdict)}}
     {{$items := $store.items}}
     {{with $.CmdArgs}}
         {{$item := (index . 0)}}
         {{with $inventory.Get $item}}
+            {{$invData := .}}
             {{$invQuantity := .quantity}}
-            {{$shopItem := $item}}
-            {{if $items.Get $item}}
-                {{$shopItem = (print $item "." $.User.Username)}}
-            {{end}}
-            {{$item := $inventory.Get $item}}
+            {{$shopItem := (print $item "." $.User.Username)}}
             {{if gt (len $.CmdArgs) 1}}
                 {{$price := (index $.CmdArgs 1)}}
                 {{if toInt $price}}
                     {{$sellQuantity := 1}}
-                    {{$cont = 0}}
-                    {{if gt (len $.CmdArgs) 1}}
-                        {{$sellQuantity = (index . 1)}}
+                    {{$cont := 1}}
+                    {{if gt (len $.CmdArgs) 2}}
+                        {{$sellQuantity = (index $.CmdArgs 2)}}
                         {{if toInt $sellQuantity}}
-                            {{if ge (toInt $sellQuantity) 1}}
+                            {{if ge (toInt $sellQuantity) 2}}
                                 {{if le (toInt $sellQuantity) (toInt $invQuantity)}}
-                                    {{$cont = true}}
                                     {{$invQuantity = sub $invQuantity $sellQuantity}}
                                 {{else}}
                                     {{$embed.Set "description" (print "There's not enough of this in the shop to buy that much!")}}
                                     {{$embed.Set "color" $errorColor}}
+                                    {{$cont = 0}}
                                 {{end}}
                             {{else}}
                                 {{$embed.Set "description" (print "Invalid quantity argument provided :(\nSyntax is `" $.Cmd "<Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
                                 {{$embed.Set "color" $errorColor}}
+                                {{$cont = 0}}
                             {{end}}
                         {{else}}
                             {{$sellQuantity = lower $sellQuantity}}
                             {{if eq (toString $sellQuantity) "all"}}
                                 {{$sellQuantity = $invQuantity}}
                                 {{$invQuantity = 0 }}
-                                {{$cont = 1}}
                             {{else}}
                                 {{$embed.Set "description" (print "Invalid quantity argument provided :(\nSyntax is `" $.Cmd "<Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
                                 {{$embed.Set "color" $errorColor}}
+                                {{$cont = 0}}
                             {{end}}
                         {{end}}
+                    {{else}}
+                        {{$invQuantity = sub $invQuantity $sellQuantity}}
                     {{end}}
                     {{if $cont}}
-                        
+						{{if not (eq $item "chicken")}}
+                            {{if not $invQuantity}}
+                                {{$inventory.Del $item}}
+                            {{else}}
+                                {{$invData.Set "quantity" $invQuantity}}
+                            {{end}}
+                            {{dbSet $userID "userEconData" $userData}}
+                            {{$shopData := .}}
+                            {{$shopData.Del "expires"}}
+                            {{$shopData.Set "quantity" $sellQuantity}}
+                            {{$shopData.Set "price" $price}}
+                            {{$shopData.Set "ID" $.User.ID}}
+                            {{if $items.Get $shopItem}}
+                                {{$shopData.Set "quantity" (add ($items.Get $shopItem).quantity $sellQuantity)}}
+                                {{$shopData.Set "price" $price}}
+                            {{end}}
+                            {{$items.Set $shopItem $shopData}}
+                            {{$desc := (print "You've added " $sellQuantity " " $item "(s) to the shop. Selling for " $symbol $price "\nThis item is listed as `" $shopItem "`")}}
+                            {{$embed.Set "description" $desc}}
+                            {{$embed.Set "color" $successColor}}
+                        {{else}}
+                            {{$embed.Set "description" (print "You cannot sell this item.")}}
+                            {{$embed.Set "color" $errorColor}}
+                        {{end}}
                     {{end}}
                 {{else}}
-                    {{$embed.Set "description" (print "Invalid `price` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+                    {{$embed.Set "description" (print "Invalid `price` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
                     {{$embed.Set "color" $errorColor}}
                 {{end}}
             {{else}}
-                {{$embed.Set "description" (print "No `price` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+                {{$embed.Set "description" (print "No `price` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
                 {{$embed.Set "color" $errorColor}}
             {{end}}
         {{else}}
-            {{$embed.Set "description" (print "Invalid `item` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+            {{$embed.Set "description" (print "Invalid `item` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]`\n\nTo view your items, run `" $prefix "inventory`")}}
             {{$embed.Set "color" $errorColor}}
         {{end}}
     {{else}}
-        {{$embed.Set "description" (print "No `item` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]")}}
+        {{$embed.Set "description" (print "No `item` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
         {{$embed.Set "color" $errorColor}}
     {{end}}
-    {{dbSet 0 "store"}}
-    {{dbSet $userID "userEconData" $userData}}
+    {{dbSet 0 "store" $store}}
 {{else}}
     {{$embed.Set "description" (print "No `Settings` database found.\nPlease set it up with the default values using `" $prefix "server-set default`")}}
     {{$embed.Set "color" $errorColor}}

--- a/Economy/Plugins/Sell/sell.cc.go
+++ b/Economy/Plugins/Sell/sell.cc.go
@@ -34,15 +34,61 @@
     {{with $.CmdArgs}}
         {{$item := (index . 0)}}
         {{with $inventory.Get $item}}
-            {{$shopEntry := .}}
-            {{$shopEntry.Set "user" $userID}}
-            {{$items.Set $item $shopEntry}}
+            {{$invQuantity := .quantity}}
+            {{$shopItem := $item}}
+            {{if $items.Get $item}}
+                {{$shopItem = (print $item "." $.User.Username)}}
+            {{end}}
+            {{$item := $inventory.Get $item}}
+            {{if gt (len $.CmdArgs) 1}}
+                {{$price := (index $.CmdArgs 1)}}
+                {{if toInt $price}}
+                    {{$sellQuantity := 1}}
+                    {{$cont = 0}}
+                    {{if gt (len $.CmdArgs) 1}}
+                        {{$sellQuantity = (index . 1)}}
+                        {{if toInt $sellQuantity}}
+                            {{if ge (toInt $sellQuantity) 1}}
+                                {{if le (toInt $sellQuantity) (toInt $invQuantity)}}
+                                    {{$cont = true}}
+                                    {{$invQuantity = sub $invQuantity $sellQuantity}}
+                                {{else}}
+                                    {{$embed.Set "description" (print "There's not enough of this in the shop to buy that much!")}}
+                                    {{$embed.Set "color" $errorColor}}
+                                {{end}}
+                            {{else}}
+                                {{$embed.Set "description" (print "Invalid quantity argument provided :(\nSyntax is `" $.Cmd "<Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
+                                {{$embed.Set "color" $errorColor}}
+                            {{end}}
+                        {{else}}
+                            {{$sellQuantity = lower $sellQuantity}}
+                            {{if eq (toString $sellQuantity) "all"}}
+                                {{$sellQuantity = $invQuantity}}
+                                {{$invQuantity = 0 }}
+                                {{$cont = 1}}
+                            {{else}}
+                                {{$embed.Set "description" (print "Invalid quantity argument provided :(\nSyntax is `" $.Cmd "<Item:Item name> <Price:Int> [Quantity:Int/All]`")}}
+                                {{$embed.Set "color" $errorColor}}
+                            {{end}}
+                        {{end}}
+                    {{end}}
+                    {{if $cont}}
+                        
+                    {{end}}
+                {{else}}
+                    {{$embed.Set "description" (print "Invalid `price` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+                    {{$embed.Set "color" $errorColor}}
+                {{end}}
+            {{else}}
+                {{$embed.Set "description" (print "No `price` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+                {{$embed.Set "color" $errorColor}}
+            {{end}}
         {{else}}
-            {{$embed.Set "description" (print "Invalid <item> argument provided.\nSyntax is `" $.Cmd " <Item:Item name> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
+            {{$embed.Set "description" (print "Invalid `item` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]\n\nTo view your items, run " $prefix "inventory`")}}
             {{$embed.Set "color" $errorColor}}
         {{end}}
     {{else}}
-        {{$embed.Set "description" (print "No <item> argument provided.\nSyntax is `" $.Cmd " <Item:Item name> [Quantity:Int/All]")}}
+        {{$embed.Set "description" (print "No `item` argument provided.\nSyntax is `" $.Cmd " <Item:Item name> <Price:Int> [Quantity:Int/All]")}}
         {{$embed.Set "color" $errorColor}}
     {{end}}
     {{dbSet 0 "store"}}

--- a/Economy/Settings-administrative/leaveMessageAlt.cc.go
+++ b/Economy/Settings-administrative/leaveMessageAlt.cc.go
@@ -35,3 +35,11 @@ To retrieve a users economy data upon rejoining
 		{{dbDel $.User.ID "userEconData"}}
 	{{end}}
 {{end}}
+{{$shop := (dbGet 0 "store").Value}}
+{{$shop := $shop.items}}
+{{- range $k, $v := $shop -}}
+  {{- if and $v.ID (eq (toInt $v.ID) (toInt $.User.ID)) -}}
+    {{- $shop.Del $k -}}
+  {{- end -}}
+{{end}}
+{{dbSet 0 "store" (sdict "items" $shop)}}

--- a/Economy/Shop/buy-item.cc.go
+++ b/Economy/Shop/buy-item.cc.go
@@ -95,7 +95,7 @@
 							{{if not (and (eq $name "chicken") (gt (toInt $buyQuantity) 1))}}
 								{{$price = mult $buyQuantity $price}}
 								{{if ge $bal $price}}
-									{{if not (and $item.ID (eq $item.ID $.User.ID))}}
+									{{if not (and $item.ID (eq (toInt $item.ID) (toInt $.User.ID)))}}
 										{{$userQuantity = add $userQuantity $buyQuantity}}
 										{{$bal = sub $bal $price}}
 										{{if not $shopQuantity}}

--- a/Economy/Shop/item-info.cc.go
+++ b/Economy/Shop/item-info.cc.go
@@ -50,7 +50,7 @@
 					{{if (toDuration $exp)}}
 						{{$exp = humanizeDurationSeconds (mult $exp $.TimeSecond)}}
 					{{end}}
-					{{$user := $item.user}}
+					{{$user := $item.ID}}
 					{{$embed.Set "title" (print "**Item info**")}}
 					{{$embed.Set "fields" (cslice 
 						(sdict "name" "Name" "value" (print $name) "inline" true)
@@ -66,7 +66,7 @@
 					{{if $user}}
 						{{$fields := $embed.fields}}
 						{{$fields = $fields.Append (sdict "name" "On market from" "value" (print "<@!" $user ">"))}}
-						{{$embed.set "fields" $fields}}
+						{{$embed.Set "fields" $fields}}
 					{{end}}
 					{{$embed.Set "color" $successColor}}
 				{{else}}

--- a/Economy/Shop/item-info.cc.go
+++ b/Economy/Shop/item-info.cc.go
@@ -50,6 +50,7 @@
 					{{if (toDuration $exp)}}
 						{{$exp = humanizeDurationSeconds (mult $exp $.TimeSecond)}}
 					{{end}}
+					{{$user := $item.user}}
 					{{$embed.Set "title" (print "**Item info**")}}
 					{{$embed.Set "fields" (cslice 
 						(sdict "name" "Name" "value" (print $name) "inline" true)
@@ -62,6 +63,11 @@
 						(sdict "name" "Reply message" "value" $reply)
 						(sdict "name" "Inventory expiry" "value" $exp)
 					)}}
+					{{if $user}}
+						{{$fields := $embed.fields}}
+						{{$fields = $fields.Append (sdict "name" "On market from" "value" (print "<@!" $user ">"))}}
+						{{$embed.set "fields" $fields}}
+					{{end}}
 					{{$embed.Set "color" $successColor}}
 				{{else}}
 					{{$embed.Set "description" (print "Invalid item argument provided :(\nSyntax is `" $.Cmd " <Name>`")}}

--- a/Economy/Shop/shop.cc.go
+++ b/Economy/Shop/shop.cc.go
@@ -51,7 +51,12 @@
 					{{else}}
 						{{$qty = "Infinite"}}
 					{{end}}
-					{{$entry = $entry.Append (sdict "Name" (print $item " - " $price " - " $qty) "value"  $desc "inline" false)}}
+					{{$user := $v.user}}
+					{{if $user}}
+						{{$entry = $entry.Append (sdict "Name" (print $item " - " $price " - " $qty " - <@!" $user ">") "value"  $desc "inline" false)}}
+					{{else}}
+						{{$entry = $entry.Append (sdict "Name" (print $item " - " $price " - " $qty) "value"  $desc "inline" false)}}
+					{{end}}
 				{{end}}
 				{{$page := ""}}
 				{{if $.CmdArgs}}

--- a/Economy/Shop/shop.cc.go
+++ b/Economy/Shop/shop.cc.go
@@ -51,9 +51,9 @@
 					{{else}}
 						{{$qty = "Infinite"}}
 					{{end}}
-					{{$user := $v.user}}
+					{{$user := $v.ID}}
 					{{if $user}}
-						{{$entry = $entry.Append (sdict "Name" (print $item " - " $price " - " $qty " - <@!" $user ">") "value"  $desc "inline" false)}}
+						{{$entry = $entry.Append (sdict "Name" (print $item " - " $price " - " $qty " - " $user ) "value"  $desc "inline" false)}}
 					{{else}}
 						{{$entry = $entry.Append (sdict "Name" (print $item " - " $price " - " $qty) "value"  $desc "inline" false)}}
 					{{end}}


### PR DESCRIPTION
Implements the sell-item plugin. Allows users to add items to the shop;

Sell item allows users to add items from their own inventories into the server shop. Once their item is bought they will receive money for it

- Sell-item is specifically for any "limited" or "special" items administrators might add to their server shop.
- Users will be unable to buy their own items. This is done to prevent abuse on the item expiry.
- Shop will be checked upon leaving and any of the users items will be purged.